### PR TITLE
Switched to copying timestamped files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       #   from this Docker container, and any writes will be overwritten by the generator.
       IS_PRIMARY: true
       LITEFS_CLOUD_TOKEN: ${LITEFS_CLOUD_TOKEN}
+      FILE_RETENTION_COUNT: ${FILE_RETENTION_COUNT}
       DOMAIN_DB_NAME: Domain.sqlite3
     volumes:
-      - ${VORIPOS_DATA_DIR}:/host-data
+      # Bind mounts help decrease data transfer latency. We no longer perform SQLite restores but,
+      # when we tested them with bind mounts, the bind mount dropped restore time from 4 minutes down to 20 seconds.
+      - type: bind
+        source: ${VORIPOS_DATA_DIR}
+        target: /host-data

--- a/voripos-domain-sync.sh
+++ b/voripos-domain-sync.sh
@@ -6,6 +6,17 @@ export PATH="/usr/local/bin:$PATH"
 # NOTE: Bash must be given Full Disk Access in order to read the user defaults.
 #   See https://www.kith.org/jed/2022/02/15/launchctl-scheduling-shell-scripts-on-macos-and-full-disk-access/.
 export LITEFS_CLOUD_TOKEN=$(defaults read com.vori.VoriPOS provisioned_litefsCloudToken)
-export VORIPOS_DATA_DIR="~/Library/Containers/com.vori.VoriPOS/Data/Library/Application Support"
+export VORIPOS_DATA_DIR="$HOME/Library/Containers/com.vori.VoriPOS/Data/Library/Application Support/Domain"
+
+# Keep the most-recent 100 files to ensure we (a) don't fill the disk while
+# and (b) don't delete a database that may be in use.
+export FILE_RETENTION_COUNT=100
+
+# The directory must exist for bind mounts to work
+mkdir -p "$VORIPOS_DATA_DIR"
+echo "Data will be replicated to $VORIPOS_DATA_DIR"
+echo "Current contents of $VORIPOS_DATA_DIR:"
+ls -al "$VORIPOS_DATA_DIR"
+
 docker compose -f $( dirname -- "$0"; )/docker-compose.yml down
 docker compose -f $( dirname -- "$0"; )/docker-compose.yml up


### PR DESCRIPTION
We now create new timestamped files with the latest domain data instead of restoring to an existing file. This ensures the app does not take any downtime during the restore operation (which takes up to 20s to complete with a bind mount, and 4 minutes without). We are also using bind mounts to speed up transfers.